### PR TITLE
Sync time for devices that lack a realtime clock

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -64,7 +64,7 @@ class App extends React.Component<{}, AppState> {
   }
 
   render() {
-    let {header, date} = this.state;
+    const {header, date} = this.state;
     return (
       <>
         <div className="flex p-10 pt-5 bg-indigo-200 bg-opacity-75 h-screen justify-around">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -15,7 +15,7 @@ function Header({headerData, date, use24Hour}: props) {
     const temperature = scrubTemperature(headerData.temperature);
     const time = use24Hour
         ? `${date.getHours()}`.padStart(2, '0') + ':' + `${date.getMinutes()}`.padStart(2, '0')
-        : `${date.getHours()}:` + `${date.getMinutes()}`.padStart(2, '0');
+        : `${((date.getHours() + 11) % 12) + 1}:` + `${date.getMinutes()}`.padStart(2, '0');
     
     return (
         <div className="flex flex-row bg-white py-2 px-12 shadow-xl rounded-lg">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,12 +5,17 @@ import { daysOfWeek, monthsOfYear } from '../interfaces/Calendar';
 
 interface props {
     headerData: HeaderProps,
+    date: Date,
+    use24Hour: boolean,
 }
 
-function Header({ headerData }: props) {
-    const dayOfWeek:string = daysOfWeek[headerData.date.getDay() - 1];
-    const formattedDateString:string = `${monthsOfYear[headerData.date.getMonth()]} ${headerData.date.getDate()}, ${headerData.date.getFullYear()}`;
+function Header({headerData, date, use24Hour}: props) {
+    const dayOfWeek:string = daysOfWeek[date.getDay() - 1];
+    const formattedDateString:string = `${monthsOfYear[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()}`;
     const temperature = scrubTemperature(headerData.temperature);
+    const time = use24Hour
+        ? `${date.getHours()}`.padStart(2, '0') + ':' + `${date.getMinutes()}`.padStart(2, '0')
+        : `${date.getHours()}:` + `${date.getMinutes()}`.padStart(2, '0');
     
     return (
         <div className="flex flex-row bg-white py-2 px-12 shadow-xl rounded-lg">
@@ -31,7 +36,7 @@ function Header({ headerData }: props) {
             </div>
 
             <div className="w-5/12 flex flex-col text-right">
-                <div className="font-thin text-5xl mb-2 text-teal-300">{headerData.time}</div>
+                <div className="font-thin text-5xl mb-2 text-teal-300">{time}</div>
                 <div className="font-thin text-2xl text-gray-500">{dayOfWeek}</div>
                 <div className="font-thin text-2xl text-gray-500">{formattedDateString}</div>
             </div>

--- a/src/components/ThermModal.tsx
+++ b/src/components/ThermModal.tsx
@@ -29,7 +29,7 @@ export default function ThermModal(props: ThermModalProps) {
                 </div>
                 <button className="bg-red-600 bg-opacity-75 p-3 mt-20 text-xl rounded-lg text-white font-thin " onClick={() => props.updateModalDisplay()}>Close</button>
             </div>      
-                <ThermPanelChild thermostat={props.therma} updateModalDisplay={() => {}} width="1/2"/>
+                <ThermPanelChild thermostat={props.therma} past={[]} updateModalDisplay={() => {}} width="1/2"/>
             </div>
         </div>
     );

--- a/src/components/ThermPanel.tsx
+++ b/src/components/ThermPanel.tsx
@@ -5,18 +5,22 @@ import Therma from '../interfaces/Therm';
 interface ThermaProps {
     thermostatData: Therma[],
     expandThermPanel: Function,
+    pastData: Therma[],
 }
 
 function ThermPanel(props: ThermaProps) {
+    let pastData = (therma: Therma) => props.pastData.filter(theTherma => therma.name === theTherma.name);
     return (
         <>
             <div className="flex flex-col mt-10">
             <div className="flex flex-col">
-                <div className="inline-flex w-1/4 pl-1 font-thin text-white bg-indigo-700 justify-center mb-2 p-2 rounded-lg bg-opacity-75 shadow-lg text-lg">Thermostat Readings - last 30 min</div>
+                <div className="inline-flex w-1/4 pl-1 font-thin text-white bg-indigo-700 justify-center mb-2 p-2 rounded-lg bg-opacity-75 shadow-lg text-lg">Thermostat Readings</div>
             </div>
             </div>
             <div className="flex flex-row p-5 rounded-lg shadow-lg bg-blue-100 bg-opacity-75 mb-10 justify-start border border-solid border-indigo-200">
-                { props.thermostatData.map((thermostat, index) => <ThermPanelChild thermostat={thermostat} width="1/4" key={index} id={index} updateModalDisplay={props.expandThermPanel} />) }
+                {props.thermostatData.map((thermostat, index) => 
+                    <ThermPanelChild thermostat={thermostat} past={pastData(thermostat)} width="1/4" key={index} id={index} updateModalDisplay={props.expandThermPanel} />)
+                }
             </div>
         </>
     );

--- a/src/components/ThermPanelChild.tsx
+++ b/src/components/ThermPanelChild.tsx
@@ -20,15 +20,53 @@ const state = {
 
 function ThermPanelChild(props:ThermChildProps) {
     const termperature = scrubTemperature(props.thermostat.temperature);
-    const data = {
+    let data = {
         labels: ['12:00', '2:00', '4:00', '6:00', '8:00', '10:00', '12:00'], // TODO
         datasets: [{
+            label: 'deg F',
             fill: false,
             lineTension: 0.5,
             backgroundColor: 'rgba(75,192,192,1)',
             borderColor: '#79E3CF',
             data: props.past.map(therm => therm.temperature),
+            yAxisID: 't',
         }],
+    }
+    let yAxes = [{
+        gridLines: {
+           display: true,
+           color: '#CDFCE5',
+        },
+        ticks: {
+            display: true,
+            fontFamily: 'system-ui',
+            fontSize: 10,
+        },
+        id: 't',
+     }];
+
+    if (props.thermostat.is_hygrostat) {
+        data.datasets.push({
+            label: '%RH',
+            fill: false,
+            lineTension: 0.5,
+            backgroundColor: 'rgba(75,192,192,1)',
+            borderColor: 'red',
+            data: props.past.map(therm => therm.relative_humidity),
+            yAxisID: 'rh',
+        });
+        yAxes.push({
+            gridLines: {
+               display: true,
+               color: '#CDFCE5',
+            },
+            ticks: {
+                display: true,
+                fontFamily: 'system-ui',
+                fontSize: 10,
+            },
+            id: 'rh',
+         });
     }
     
     return (
@@ -39,6 +77,9 @@ function ThermPanelChild(props:ThermChildProps) {
                         {props.thermostat.name}
                         <PlusSvg className="ml-1 w-5 h-5"/>
                     </div>
+                    {!props.thermostat.is_hygrostat ? null : (<>
+                        {props.thermostat.relative_humidity}%RH
+                    </>)}
                     <div className="bg-teal-400 px-2 py-1 rounded-full text-xs text-white mt-1">Madison, WI</div>
                 </div>
                 <div className="text-5xl font-thin text-gray-600">
@@ -67,17 +108,7 @@ function ThermPanelChild(props:ThermChildProps) {
                                    fontSize: 10,
                                }
                             }],
-                            yAxes: [{
-                               gridLines: {
-                                  display: true,
-                                  color: '#CDFCE5',
-                               },
-                               ticks: {
-                                   display: true,
-                                   fontFamily: 'system-ui',
-                                   fontSize: 10,
-                               }
-                            }]
+                            yAxes,
                        },
                        responsive: true,
                        maintainAspectRatio: true

--- a/src/components/ThermPanelChild.tsx
+++ b/src/components/ThermPanelChild.tsx
@@ -20,6 +20,16 @@ const state = {
 
 function ThermPanelChild(props:ThermChildProps) {
     const termperature = scrubTemperature(props.thermostat.temperature);
+    const data = {
+        labels: ['12:00', '2:00', '4:00', '6:00', '8:00', '10:00', '12:00'], // TODO
+        datasets: [{
+            fill: false,
+            lineTension: 0.5,
+            backgroundColor: 'rgba(75,192,192,1)',
+            borderColor: '#79E3CF',
+            data: props.past.map(therm => therm.temperature),
+        }],
+    }
     
     return (
         <button id={props.id} type="button" className={`bg-white mr-5 shadow-lg rounded-lg flex flex-col justify-around px-1 py-2 w-${props.width}`} onClick={(e) => props.updateModalDisplay(e)}>
@@ -37,7 +47,7 @@ function ThermPanelChild(props:ThermChildProps) {
             </div>
             <div className="w-full mx-auto">
                 <Line
-                    data={state}
+                    data={data}
                     options={{
                         title: { 
                         display:false,

--- a/src/config_example.ts
+++ b/src/config_example.ts
@@ -1,7 +1,8 @@
-const host:string = 'http://localhost';
+export const host:string = 'http://localhost';
 const port:number = 3000;
 
 const city:string = 'Madison';
 const state:string = 'Wisconsin';
+export const timeZone:string = 'America/Chicago';
 
 export default { host, port, city, state };

--- a/src/helpers/trackTime.tsx
+++ b/src/helpers/trackTime.tsx
@@ -1,27 +1,44 @@
-import App from "../components/App";
+import {host, timeZone} from '../config';
 
-function calculateTime(this: App): void {
-    const wisconsinDateStr:string = new Date().toLocaleString("en-US", {timeZone: "America/Menominee"});
-    const wisconsinTime:Date = new Date(wisconsinDateStr);
-    
-    let hours:string|number = wisconsinTime.getHours();
-    let minutes:string|number = wisconsinTime.getMinutes();
+let lastTimestamp: Date|undefined;
+let offset = 0;
 
-    hours = hours < 10 ? `0${hours}` : hours;
-    minutes = minutes < 10 ? '0' + minutes : minutes;
-
-    this.setState({
-      header: {
-        ...this.state.header,
-        time: `${hours}:${minutes}`,
-      }
+/**
+ * Sets the difference between local system time and the API server.
+ */
+function getOffset(): void {
+  fetch(`${host}/time`)
+    .then(text => {
+      offset = (new Date()).getTime() - (parseInt(text, 10) * 1000);
     });
-};
+}
 
-export default function trackTime(this: App): void {
-  calculateTime.call(this);
-  setTimeout(() => {
-    calculateTime.call(this);
-    setInterval(calculateTime.bind(this), 1000);
-  }, 60000 - this.state.header.date.getSeconds() * 1000);
+/**
+ * Returns either the current target system date, or undefined if the
+ * request is throttled. Because we only show the date to the minute,
+ * we throttle requests until the minutes are different, to avoid unecessary
+ * state changes.
+ */
+export function getDate(): Date|undefined {
+  // Get the current system date converted into target time zone
+  let now: Date;
+  now = new Date((new Date()).getTime() + offset);
+  now = new Date(now.toLocaleString('en-US', {timeZone}));
+
+  // If there is no lastTimestamp, you should calculate the offset
+  // between server time and local time, and yield the current timestamp.
+  if (lastTimestamp === undefined) {
+    getOffset();
+    lastTimestamp = now;
+    return now;
+  } 
+  
+  // Otherwise, check if the minutes differ and yield that timestamp.
+  else if (lastTimestamp.getMinutes() !== now.getMinutes()) {
+    lastTimestamp = now;
+    return now;
+  }
+
+  // UI is current, no updates are necessary.
+  return undefined;
 }

--- a/src/helpers/trackTime.tsx
+++ b/src/helpers/trackTime.tsx
@@ -8,6 +8,7 @@ let offset = 0;
  */
 function getOffset(): void {
   fetch(`${host}/time`)
+    .then(res => res.text())
     .then(text => {
       offset = (new Date()).getTime() - (parseInt(text, 10) * 1000);
     });

--- a/src/interfaces/App.tsx
+++ b/src/interfaces/App.tsx
@@ -16,7 +16,7 @@ export function init(): AppState {
     return {
         date: new Date(),
         header: {city: '', state: '', temperature: 0},
-        thermostats: [{id: 0, name: '', temperature: 0, is_hygrostat: false, time: ''}],
+        thermostats: [{id: 0, name: '', temperature: 0, is_hygrostat: false, time: '', relative_humidity: 0}],
         past: [],
         forecast: [{date: '', condition: '', day_temp: 0, night_temp: 0}],
         showThermModal: false,

--- a/src/interfaces/App.tsx
+++ b/src/interfaces/App.tsx
@@ -3,6 +3,7 @@ import ThermostatState from '../interfaces/Therm';
 import ForecastState from '../interfaces/Forecast';
 
 export interface AppState {
+    date: Date;
     header: HeaderState;
     thermostats: ThermostatState[],
     forecast: ForecastState[],
@@ -12,7 +13,8 @@ export interface AppState {
 
 export function init(): AppState {
     return {
-        header: {city: '', state: '', date: new Date(), temperature: 0, time: ''},
+        date: new Date(),
+        header: {city: '', state: '', temperature: 0},
         thermostats: [{id: 0, name: '', temperature: 0, is_hygrostat: false, time: ''}],
         forecast: [{date: '', condition: '', day_temp: 0, night_temp: 0}],
         showThermModal: false,

--- a/src/interfaces/App.tsx
+++ b/src/interfaces/App.tsx
@@ -6,6 +6,7 @@ export interface AppState {
     date: Date;
     header: HeaderState;
     thermostats: ThermostatState[],
+    past: ThermostatState[],
     forecast: ForecastState[],
     showThermModal: boolean,
     thermModalIdx: number,
@@ -16,6 +17,7 @@ export function init(): AppState {
         date: new Date(),
         header: {city: '', state: '', temperature: 0},
         thermostats: [{id: 0, name: '', temperature: 0, is_hygrostat: false, time: ''}],
+        past: [],
         forecast: [{date: '', condition: '', day_temp: 0, night_temp: 0}],
         showThermModal: false,
         thermModalIdx: -1,

--- a/src/interfaces/Header.tsx
+++ b/src/interfaces/Header.tsx
@@ -1,17 +1,13 @@
 export default interface Header {
     city: string,
     state: string,
-    date: Date,
-    time: string,
     temperature: number,
 }
 
-export function generateHeader(city:string, state:string, temperature?: number, date?: Date, time?: string):Header {
+export function generateHeader(city:string, state:string, temperature?: number):Header {
     return {
         city,
         state,
         temperature: temperature ?? 0,
-        date: date ?? new Date(),
-        time: time ?? '',
     }
 }

--- a/src/interfaces/NowResponse.ts
+++ b/src/interfaces/NowResponse.ts
@@ -1,0 +1,7 @@
+import Therma from "./Therm";
+import Forecast from "./Forecast";
+
+export interface NowResponse {
+    forecast: Forecast[],
+    thermostats: Therma[],
+}

--- a/src/interfaces/Therm.tsx
+++ b/src/interfaces/Therm.tsx
@@ -4,4 +4,5 @@ export default interface Therma {
     temperature: number,
     time: string,
     is_hygrostat: boolean,
+    relative_humidity: number,
 }

--- a/src/interfaces/ThermChildProps.tsx
+++ b/src/interfaces/ThermChildProps.tsx
@@ -2,6 +2,7 @@ import Therma from "./Therm";
 
 export default interface ThermChildProps {
     thermostat: Therma,
+    past: Therma[],
     updateModalDisplay: Function,
     width: string,
     id?: any,


### PR DESCRIPTION
This update fixes inaccurate times on devices that lack an RTC. It does this by calculating a time offset between the local system and the server, as well as allowing a timezone to be configured in config. This basically allows the app to be deployed to any device without ever configuring it's clock and it will render the proper time.

The state variable `date` was moved up a layer because it was not in a place that was easy to update. It is passed into Header via props. A new prop was added to the header for `use24Hour` format. This creates a pathway in for future settings.