### PR TITLE
Picture frame mode

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,16 +1,18 @@
 import React from 'react';
 import CONFIG from '../config';
 import { Dashboard, Screensaver } from './';
-import { AppState, init, DegreesFormat, generateHeader, NowResponse, Therm, TimeFormat } from '../interfaces';
+import { DegreesFormat, generateHeader, NowResponse, Therm, TimeFormat } from '../interfaces';
 import { convertBinaryToBase64, getDate, getNow } from '../helpers'
 import { closeModal, expandThermPanel, setTemperatureFormat, setTimeFormat, toggleRaspberrySettings, setThermInterval } from '../eventHandlers';
+import { AppState, Screen } from '../interfaces/App';
+import ScreenSaver from './Screensaver';
 
 class App extends React.Component<{}, AppState> {
 	private timeThread = 0;
 
 	constructor(props: {}) {
 		super(props);
-		this.state = init();
+		this.state = AppState.default();
 
 		this.closeModal = closeModal.bind(this);
 		this.expandThermPanel = expandThermPanel.bind(this);
@@ -48,7 +50,7 @@ class App extends React.Component<{}, AppState> {
 		this.timeThread = window.setInterval(() => {
 			const date = getDate();
 			if (date !== undefined) {
-				this.setState({ date });
+				this.setState({ date, screen: Screen.ScreenSaver });
 				this.updateData(date);
 			}
 		}, 2000);
@@ -63,8 +65,7 @@ class App extends React.Component<{}, AppState> {
 				this.setState({
 					header: generateHeader(CONFIG.city, CONFIG.state, currentWeatherData?.temperature),
 					thermostats,
-					forecast_daily,
-					date: now,
+					forecastDaily: forecast_daily,
 				});
 			});
 		await this.fetchPast(new Date(now.getTime() - 43200000), now)
@@ -93,30 +94,30 @@ class App extends React.Component<{}, AppState> {
 	}
 
 	render() {
-		const { header, date, forecast_daily, use24Hour, degreesFormat, past, screenSaverSrc, showScreenSaver, showThermModal, showRaspberrySettings, thermModalIdx, thermInterval, thermostats } = this.state;
+		const { header, date, forecastDaily, use24Hour, degreesFormat, past, screenSaverSrc, screen, showThermModal, showRaspberrySettings, thermModalIdx, thermInterval, thermostats } = this.state;
 		return (
 			<>
-				{showScreenSaver ? <Screensaver screenSaverSrc={screenSaverSrc} /> : (
-					<Dashboard
-						header={header}
-						date={date}
-						forecast_daily={forecast_daily}
-						use24Hour={use24Hour}
-						degreesFormat={degreesFormat}
-						past={past}
-						showThermModal={showThermModal}
-						showRaspberrySettings={showRaspberrySettings}
-						thermInterval={thermInterval}
-						setTemperatureFormat={this.setTemperatureFormat}
-						setThermInterval={this.setThermInterval}
-						setTimeFormat={this.setTimeFormat}
-						thermModalIdx={thermModalIdx}
-						toggleRaspberrySettings={this.toggleRaspberrySettings}
-						thermostats={thermostats}
-						updateModalDisplay={this.closeModal}
-						expandThermPanel={this.expandThermPanel}
-					/>
-				)}
+				<ScreenSaver date={date} screenSaverSrc={screenSaverSrc} screen={screen} tap={() => this.setState({ screen: Screen.Dashboard })} />
+				<Dashboard
+					header={header}
+					date={date}
+					forecast_daily={forecastDaily}
+					use24Hour={use24Hour}
+					degreesFormat={degreesFormat}
+					past={past}
+					showThermModal={showThermModal}
+					showRaspberrySettings={showRaspberrySettings}
+					thermInterval={thermInterval}
+					setTemperatureFormat={this.setTemperatureFormat}
+					setThermInterval={this.setThermInterval}
+					setTimeFormat={this.setTimeFormat}
+					screen={screen}
+					thermModalIdx={thermModalIdx}
+					toggleRaspberrySettings={this.toggleRaspberrySettings}
+					thermostats={thermostats}
+					updateModalDisplay={this.closeModal}
+					expandThermPanel={this.expandThermPanel}
+				/>
 			</>
 		);
 	}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -2,8 +2,12 @@ import React from 'react';
 import { AppContainer } from '../assets/cssClasses';
 import { ControlPanel, Header, RaspberrySettings, ThermModal, ThermPanel, WeatherForecast } from './';
 import { DashboardProps } from '../interfaces';
+import { Screen } from '../interfaces/App';
 
 function Dashboard(props: DashboardProps) {
+  if (props.screen !== Screen.Dashboard) {
+    return null;
+  }
   const { header, date, forecast_daily, use24Hour, degreesFormat, past, showThermModal, showRaspberrySettings, thermInterval, thermModalIdx, thermostats } = props;
   return (
     <>

--- a/src/components/Screensaver.tsx
+++ b/src/components/Screensaver.tsx
@@ -1,14 +1,42 @@
 import React from 'react';
+import { Screen } from '../interfaces/App';
 
 interface ScreenSaverProps {
+  date: Date,
+  screen: Screen,
   screenSaverSrc: string[],
-
+  tap: () => void,
 }
 
-function ScreenSaver({ screenSaverSrc }: ScreenSaverProps) {
+function ScreenSaver({ date, screen, screenSaverSrc, tap }: ScreenSaverProps) {
+  if (screen !== Screen.ScreenSaver) {
+    return null;
+  }
+
+  const background = Math.floor(date.getTime() / 60) % screenSaverSrc.length;
+  console.log(`choosing background #${background}`);
+
+  const backgroundCss = {
+    height: window.innerHeight,
+    width: window.innerWidth,
+    backgroundImage: `url('${screenSaverSrc[background]}')`,
+    backgroundPosition: 'center center',
+    backgroundSize: 'cover',
+  } as React.CSSProperties;
+
+  const timeCss = {
+    position: 'fixed',
+    right: '15px',
+    bottom: '15px',
+    fontSize: '72pt',
+    color: 'white',
+  } as React.CSSProperties;
+
   return (
-    // <div></div>
-    <img src={screenSaverSrc[0]} />
+    // TODO: Show the DoW, Date, and main Thermostat reading here
+    <div onClick={tap} style={backgroundCss}>
+      <p style={timeCss}>{date.toLocaleTimeString()}</p>
+    </div>
   )
 }
 

--- a/src/interfaces/App.ts
+++ b/src/interfaces/App.ts
@@ -1,36 +1,46 @@
 import { Forecast as ForecastState, Header as HeaderState, Therm as ThermostatState } from '../interfaces';
 import SeedData from '../ThermHub_PastData';
 
-export type AppState = {
-	date: Date;
-	header: HeaderState;
-	thermostats: ThermostatState[],
-	past: ThermostatState[],
-	forecast_daily: ForecastState[],
-	showThermModal: boolean,
-	thermModalIdx: number,
-	use24Hour: boolean,
-	degreesFormat: string,
-	showRaspberrySettings: boolean,
-	thermInterval: number,
-	screenSaverSrc: string[],
-	showScreenSaver: boolean,
+export enum Screen {
+	ScreenSaver,
+	Dashboard,
+	Modal,
 }
 
-export function init(): AppState {
-	return {
-		date: new Date(),
-		header: { city: '', state: '', temperature: 0 },
-		thermostats: [{ id: 0, name: '', temperature: 0, is_hygrostat: false, time: '', relative_humidity: 0 }],
-		past: SeedData,
-		forecast_daily: [{ date: '', condition: '', day_temperature: 0, night_temperature: 0 }],
-		showThermModal: false,
-		thermModalIdx: -1,
-		use24Hour: true,
-		degreesFormat: 'Fahrenheit',
-		showRaspberrySettings: false,
-		thermInterval: 289, // representive of # of 5min intervals, 289 in 24 hours, inclusive of startTime
-		screenSaverSrc: [''],
-		showScreenSaver: true,
+export class AppState {
+	constructor(
+		public date: Date,
+		public header: HeaderState,
+		public thermostats: ThermostatState[],
+		public past: ThermostatState[],
+		public forecastDaily: ForecastState[],
+		public forecastHourly: ForecastState[],
+		public showThermModal: boolean,
+		public thermModalIdx: number,
+		public use24Hour: boolean,
+		public degreesFormat: string,
+		public showRaspberrySettings: boolean,
+		public thermInterval: number,
+		public screenSaverSrc: string[],
+		public screen: Screen,
+	) { }
+
+	static default(): AppState {
+		return new AppState(
+			new Date(),
+			{ city: '', state: '', temperature: 0 },
+			[],
+			[],
+			[],
+			[],
+			false,
+			-1,
+			true,
+			'Fahrenheit',
+			false,
+			289,
+			[],
+			Screen.ScreenSaver,
+		);
 	}
 }

--- a/src/interfaces/DashboardProps.ts
+++ b/src/interfaces/DashboardProps.ts
@@ -1,4 +1,5 @@
 import { Forecast as ForecastState, Header as HeaderState, Therm as ThermostatState } from '../interfaces';
+import { Screen } from './App';
 
 export type DashboardProps = {
   header: HeaderState,
@@ -13,6 +14,7 @@ export type DashboardProps = {
   setTemperatureFormat: Function,
   setThermInterval: Function,
   setTimeFormat: Function,
+  screen: Screen,
   thermModalIdx: number,
   thermInterval: number,
   thermostats: ThermostatState[],

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,5 +1,4 @@
 // Import types / interfaces
-import { AppState as AppState_ } from './App';
 import { ControlPanelProps as ControlPanelProps_ } from './ControlPanelProps';
 import { DashboardProps as DashboardProps_ } from './DashboardProps';
 import { DegreesFormat as DegreesFormat_ } from './DegreesFormat';
@@ -21,7 +20,6 @@ import Calendar from './Calendar';
 export { Calendar };
 
 // Export types / interfaces
-export type AppState = AppState_;
 export type ControlPanelProps = ControlPanelProps_;
 export type DashboardProps = DashboardProps_;
 export type DegreesFormat = DegreesFormat_;
@@ -39,5 +37,4 @@ export type ThermPanelProps = ThermPanelProps_;
 export type TimeFormat = TimeFormat_;
 
 // Types / interfaces util functions
-export { init } from './App';
 export { generateHeader } from './Header';


### PR DESCRIPTION
Updates the app to better support the picture frame. Minor improvements include:
- The screens themselves determine if they will draw. This creates fewer branches in App itself, and allows for multiple screens to be layered if desired.
- `init` has been removed from `App` and `AppState` has become a class itself. IDK why but it couldn't be piped out through the interfaces file, but I'm not sure what this file adds, anyway?